### PR TITLE
Fixed HTMLPurifier link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Where:
 |`empty`|yes|all tags will be removed|
 |`*`|no|all tags are allowed|
 
-Other values are allowed according to the  [HTMLPurifier](https://github.com/ezyang/htmlpurifier]) format.
+Other values are allowed according to the  [HTMLPurifier](https://github.com/ezyang/htmlpurifier) format.
 
 Example:
 ```


### PR DESCRIPTION
I noticed there was an issue with this link whilst reading through the README, so I figured I'd fix it.