### PR TITLE
Add tunes data to sanitised block

### DIFF
--- a/EditorJS/BlockHandler.php
+++ b/EditorJS/BlockHandler.php
@@ -65,13 +65,14 @@ class BlockHandler
      *
      * @return array|bool
      */
-    public function sanitizeBlock($blockType, $blockData)
+    public function sanitizeBlock($blockType, $blockData, $blockTunes)
     {
         $rule = $this->rules->tools[$blockType];
 
         return [
             'type' => $blockType,
-            'data' => $this->sanitize($rule, $blockData)
+            'data' => $this->sanitize($rule, $blockData),
+            'tunes' => $blockTunes
         ];
     }
 

--- a/EditorJS/EditorJS.php
+++ b/EditorJS/EditorJS.php
@@ -106,7 +106,11 @@ class EditorJS
         $sanitizedBlocks = [];
 
         foreach ($this->blocks as $block) {
-            $sanitizedBlock = $this->handler->sanitizeBlock($block['type'], $block['data']);
+            $sanitizedBlock = $this->handler->sanitizeBlock(
+                $block['type'],
+                $block['data'],
+                $block["tunes"] ?? []
+            );
             if (!empty($sanitizedBlock)) {
                 array_push($sanitizedBlocks, $sanitizedBlock);
             }


### PR DESCRIPTION
This PR passes the block tunes values through so they are present on sanitised block output.

Addresses #54.

